### PR TITLE
fix: integrate validation with new lib version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@fontsource/fira-mono": "^5.0.8",
+				"@sd-jwt/crypto-browser": "^0.4.0",
+				"@sd-jwt/crypto-nodejs": "^0.4.0",
 				"@sd-jwt/sd-jwt-vc": "^0.4",
 				"jose": "^5.2.2",
 				"monaco-editor": "^0.45.0"
@@ -860,6 +862,19 @@
 				"@sd-jwt/types": "0.4.0",
 				"@sd-jwt/utils": "0.4.0"
 			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@sd-jwt/crypto-browser": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@sd-jwt/crypto-browser/-/crypto-browser-0.4.0.tgz",
+			"integrity": "sha512-II+1EAKPLqwhxgZ++NR3Z5zvYqOWyRTlsSEcozyBl8/GFF3sVMoPos3Jvc9wU/AId6ezDvW/TbeefOgOhPy1+A=="
+		},
+		"node_modules/@sd-jwt/crypto-nodejs": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@sd-jwt/crypto-nodejs/-/crypto-nodejs-0.4.0.tgz",
+			"integrity": "sha512-P3OStMD4TgiVcPyby+3PqdsmE2yWB1e3iiC41mxa7qF+3ndrPcCVGrk9msV3Tk9/vzVtFQKTs7OamdnuV8bPXA==",
 			"engines": {
 				"node": ">=16"
 			}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
 	"type": "module",
 	"dependencies": {
 		"@fontsource/fira-mono": "^5.0.8",
+		"@sd-jwt/crypto-browser": "^0.4.0",
+		"@sd-jwt/crypto-nodejs": "^0.4.0",
 		"@sd-jwt/sd-jwt-vc": "^0.4",
 		"jose": "^5.2.2",
 		"monaco-editor": "^0.45.0"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -66,7 +66,7 @@
 		// define an instance that can be used for everything.
 		const instance = new SDJwtVcInstance({
 			signer,
-			signAlg: "EdDSA",
+			signAlg: "ES256",
 			hasher: digest,
 			hashAlg: "SHA-256",
 			saltGenerator: generateSalt,
@@ -105,8 +105,7 @@
 			} else {
 				showKeyBindingSignatureVerified = false;
 			}
-			const es = typeof window !== "undefined" ? ES256 : NodeES256;
-			const verifier = await es.getVerifier(issuerKey.publicKey);
+			const verifier = await ES256.getVerifier(issuerKey.publicKey);
 			/**
 			 * Extract the key from the cnf, only supported embedded jwk for now.
 			 */
@@ -114,7 +113,7 @@
 				if (!payload.cnf) {
 					throw new Error("No cnf in payload");
 				}
-				return es.getVerifier(payload.cnf.jwk).then((verifier) => verifier(data, key));
+				return ES256.getVerifier(payload.cnf.jwk).then((verifier) => verifier(data, key));
 			};
 
 			const instance = new SDJwtVcInstance({
@@ -124,7 +123,6 @@
 				saltGenerator: generateSalt,
 				kbVerifier,
 			});
-
 			instance
 				.verify(encodedJwt, requiredClaims, false)
 				.then(() => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,7 +11,13 @@
 		generateSalt as NodeGenerateSalt,
 	} from "@sd-jwt/crypto-nodejs";
 	import { SDJwtVcInstance } from "@sd-jwt/sd-jwt-vc";
-	import type { DisclosureFrame, PresentationFrame, Signer, KbVerifier } from "@sd-jwt/types";
+	import type {
+		DisclosureFrame,
+		PresentationFrame,
+		Signer,
+		KbVerifier,
+		JwtPayload,
+	} from "@sd-jwt/types";
 	import { onMount } from "svelte";
 	import { SDJwt } from "@sd-jwt/core";
 
@@ -28,8 +34,12 @@
 			holderKey = await ES256.generateKeyPair();
 			const kbSigner: Signer = async (data: string) =>
 				ES256.getSigner(holderKey.privateKey).then((signer) => signer(data));
-			const kbVerifier: KbVerifier = async (data: string, key: string) =>
-				ES256.getVerifier(holderKey.publicKey).then((verifier) => verifier(data, key));
+			const kbVerifier: KbVerifier = async (data: string, key: string, payload: JwtPayload) => {
+				if (!payload.cnf) {
+					throw new Error("No cnf in payload");
+				}
+				return ES256.getVerifier(payload.cnf.jwk).then((verifier) => verifier(data, key));
+			};
 
 			// define an instance that can be used for everything. In case of validation, we only need the verifier and hash functions.
 			return new SDJwtVcInstance({
@@ -50,8 +60,12 @@
 			holderKey = await ES256.generateKeyPair();
 			const kbSigner: Signer = async (data: string) =>
 				ES256.getSigner(holderKey.privateKey).then((signer) => signer(data));
-			const kbVerifier: KbVerifier = async (data: string, key: string) =>
-				ES256.getVerifier(holderKey.publicKey).then((verifier) => verifier(data, key));
+			const kbVerifier: KbVerifier = async (data: string, key: string, payload: JwtPayload) => {
+				if (!payload.cnf) {
+					throw new Error("No cnf in payload");
+				}
+				return ES256.getVerifier(payload.cnf.jwk).then((verifier) => verifier(data, key));
+			};
 			return new SDJwtVcInstance({
 				signer,
 				verifier,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"moduleResolution": "bundler"
+		"moduleResolution": "bundler",
+		"lib": ["DOM", "ESNext"]
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	//


### PR DESCRIPTION
Using @sd-jwt functions to verify the credential. To make it easier for development, the credential is created on demand since the lib provides the relevant method.

This approach is static since the instance is created on start, meaning it can only work with `EdDSA` algorithms and `SHA-256` for hashing right now. This is not the limitation of the lib itself, but the current implemented functions (bring your own crypto implementation).